### PR TITLE
Fix sync relocation

### DIFF
--- a/timeline/src/Transport.C
+++ b/timeline/src/Transport.C
@@ -21,6 +21,7 @@
 
 #include "Transport.H"
 #include "Timeline.H"
+#include <iostream>
 
 #include "Engine/Engine.H"
 
@@ -262,8 +263,11 @@ Transport::poll ( void )
 
     ts = engine->transport_query( this );
 
+	printJackTransportPos( this );
+
     rolling = ts == JackTransportRolling;
 }
+
 
 void
 Transport::locate ( nframes_t frame )
@@ -336,4 +340,22 @@ Transport::toggle ( void )
         stop();
     else
         start();
+}
+
+void Transport::printJackTransportPos( const jack_position_t* pPos ) {
+	std::cout << "\033[36m[Non-Timeline] [JACK transport]"
+			  << " frame: " << pPos->frame
+			  << ", frame_rate: " << pPos->frame_rate
+			  << std::hex << ", valid: 0x" << pPos->valid
+			  << std::dec << ", bar: " << pPos->bar
+			  << ", beat: " << pPos->beat
+			  << ", tick: " << pPos->tick
+			  << ", bar_start_tick: " << pPos->bar_start_tick
+			  << ", beats_per_bar: " << pPos->beats_per_bar
+			  << ", beat_type: " << pPos->beat_type
+			  << ", ticks_per_beat: " << pPos->ticks_per_beat
+			  << ", beats_per_minute: " << pPos->beats_per_minute
+			  << ", frame_time: " << pPos->frame_time
+			  << ", next_time: " << pPos->next_time
+			  << "\033[0m" << std::endl;
 }

--- a/timeline/src/Transport.H
+++ b/timeline/src/Transport.H
@@ -54,6 +54,9 @@ private:
 
     void update_record_state ( void );
 
+	// Print JACK transport position for debugging purposes.
+	void printJackTransportPos( const jack_position_t* pPos );
+
 public:
 
     Transport ( int X, int Y, int W, int H, const char *L=0 );


### PR DESCRIPTION
the sync callback did take the first transport position provided by the JACK server when transport is in state JackTransportStarting, requests a relocation internally, and gives its okay to the JACK server.

However, if a client triggers both a relocation and the start of the transport at the same time, the JACK server will provide two cycles in state JackTransportStarting. The first one will still contain the old location and only the second will provide the new one. This makes the `timeline` seeking the first location (wrong) and missing the proper one. At the same the JACK position stored in the client is valid and the BBT data provided as JACK master will be legit (and out of sync with the Non-timeline internal state).

In the provided fix the internal relocation will always and exclusively be triggered if the transport position provided by the JACK server does not match the one stored in the client.